### PR TITLE
Avoid extra usize array by unioning next pointer into elements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,18 +130,14 @@ impl<IT, N> Slots<IT, N>
     }
 
     fn alloc(&mut self) -> Option<usize> {
-        if self.count() == self.capacity() {
-            None
-        } else {
-            let result = self.next_free;
-            self.next_free = match self.items[result.expect("Count mismatch")] {
-                Entry::EmptyNext(n) => Some(n),
-                Entry::EmptyLast => None,
-                _ => unreachable!("Non-empty item in entry behind free chain"),
-            };
-            self.free_count -= 1;
-            result
-        }
+        let index = self.next_free?;
+        self.next_free = match self.items[index] {
+            Entry::EmptyNext(n) => Some(n),
+            Entry::EmptyLast => None,
+            _ => unreachable!("Non-empty item in entry behind free chain"),
+        };
+        self.free_count -= 1;
+        Some(index)
     }
 
     pub fn store(&mut self, item: IT) -> Result<Key<IT, N>, IT> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,12 +106,8 @@ impl<IT, N> Slots<IT, N>
         let size = N::to_usize();
 
         Self {
-            // Fill back-to-front
-            // items: GenericArray::generate(|i: usize| if i == 0 { Entry::EmptyLast } else { Entry::EmptyNext(i - 1) }),
-            // next_free: size.checked_sub(1),
-            // Fill front-to-back
-            items: GenericArray::generate(|i: usize| if i == size - 1 { Entry::EmptyLast } else { Entry::EmptyNext(i + 1) }),
-            next_free: Some(0),
+            items: GenericArray::generate(|i| i.checked_sub(1).map(Entry::EmptyNext).unwrap_or(Entry::EmptyLast)),
+            next_free: size.checked_sub(1),
             free_count: size
         }
     }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -84,7 +84,7 @@ fn store_returns_err_when_full() {
     assert!(k2.is_err());
 }
 
-#[should_panic()]
+#[should_panic(expected = "assertion failed: `(left == right)`\n  left: `792`,\n right: `536`")]
 #[test]
 /// Verify some size bounds: an N long array over IT is not larger than 3 usize + N * IT (as long
 /// as IT is larger than two usize and has two niches)
@@ -92,7 +92,11 @@ fn store_returns_err_when_full() {
 // Fails until https://github.com/rust-lang/rust/issues/46213 is resolved (possibly,
 // https://github.com/rust-lang/rust/pull/70477 is sufficient). When this starts not failing any
 // more, be happy, remove the panic, and figure out how to skip the test on older Rust versions.
+// (If left just goes down but does not reach right, that should be investigated further, as it
+// indicates that the optimization was implemented incompletely, or it turns out it is not possible
+// for some reasons and needs fixing in the code).
 fn is_compact() {
+    #[allow(unused)]
     struct TwoNichesIn16Byte {
         n1: u64,
         n2: u32,
@@ -103,6 +107,5 @@ fn is_compact() {
 
     assert_eq!(core::mem::size_of::<TwoNichesIn16Byte>(), 16);
 
-    let slots: Slots<TwoNichesIn16Byte, U32> = Slots::new();
     assert_eq!(core::mem::size_of::<Slots<TwoNichesIn16Byte, U32>>(), 32 * 16 + 3 * core::mem::size_of::<usize>());
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -33,9 +33,9 @@ fn index_can_be_used_to_read_value() {
     slots.store(6).unwrap();
     slots.store(7).unwrap();
 
-    assert_eq!(5, slots.try_read(0, |&w| w).unwrap());
-    assert_eq!(6, slots.try_read(1, |&w| w).unwrap());
-    assert_eq!(7, slots.try_read(2, |&w| w).unwrap());
+    assert_eq!(5, slots.try_read(7, |&w| w).unwrap());
+    assert_eq!(6, slots.try_read(6, |&w| w).unwrap());
+    assert_eq!(7, slots.try_read(5, |&w| w).unwrap());
 }
 
 #[test]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -83,3 +83,24 @@ fn store_returns_err_when_full() {
 
     assert!(k2.is_err());
 }
+
+#[test]
+/// Verify some size bounds: an N long array over IT is not larger than 3 usize + N * IT (as long
+/// as IT is larger than two usize and has two niches)
+//
+// Failes until https://github.com/rust-lang/rust/issues/46213 is resolved (possibly,
+// https://github.com/rust-lang/rust/pull/70477 is sufficient)
+fn is_compact() {
+    struct TwoNichesIn16Byte {
+        n1: u64,
+        n2: u32,
+        n3: u16,
+        n4: u8,
+        b: bool,
+    }
+
+    assert_eq!(core::mem::size_of::<TwoNichesIn16Byte>(), 16);
+
+    let slots: Slots<TwoNichesIn16Byte, U32> = Slots::new();
+    assert_eq!(core::mem::size_of::<Slots<TwoNichesIn16Byte, U32>>(), 32 * 16 + 3 * core::mem::size_of::<usize>());
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -84,12 +84,14 @@ fn store_returns_err_when_full() {
     assert!(k2.is_err());
 }
 
+#[should_panic()]
 #[test]
 /// Verify some size bounds: an N long array over IT is not larger than 3 usize + N * IT (as long
 /// as IT is larger than two usize and has two niches)
 //
-// Failes until https://github.com/rust-lang/rust/issues/46213 is resolved (possibly,
-// https://github.com/rust-lang/rust/pull/70477 is sufficient)
+// Fails until https://github.com/rust-lang/rust/issues/46213 is resolved (possibly,
+// https://github.com/rust-lang/rust/pull/70477 is sufficient). When this starts not failing any
+// more, be happy, remove the panic, and figure out how to skip the test on older Rust versions.
 fn is_compact() {
     struct TwoNichesIn16Byte {
         n1: u64,

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -109,3 +109,28 @@ fn is_compact() {
 
     assert_eq!(core::mem::size_of::<Slots<TwoNichesIn16Byte, U32>>(), 32 * 16 + 3 * core::mem::size_of::<usize>());
 }
+
+#[test]
+fn capacity_and_count() {
+    let mut slots: Slots<u8, U4> = Slots::new();
+
+    assert_eq!(slots.capacity(), 4);
+    assert_eq!(slots.count(), 0);
+
+    let k1 = slots.store(1).unwrap();
+    let k2 = slots.store(2).unwrap();
+
+    assert_eq!(slots.count(), 2);
+
+    let k3 = slots.store(3).unwrap();
+    let k4 = slots.store(4).unwrap();
+
+    assert_eq!(slots.count(), 4);
+
+    slots.take(k1);
+    slots.take(k2);
+    slots.take(k3);
+    slots.take(k4);
+
+    assert_eq!(slots.count(), 0);
+}


### PR DESCRIPTION
This does not yet realize the space savings it promises in the test case
due to missing optimizations ([1], [2]) in Rust, but should eventually manage
to be barely larger than the payload arrays.

[1]: https://github.com/rust-lang/rust/issues/46213
[2]: https://github.com/rust-lang/rust/pull/70477

---

The current code has parallel arrays for used and free slots, where actually only ever one or the other is ever used. By putting them in a single enum, a slot is either used for the free list or for data.

Ideally, this would do away with the need for per-element data completely, provided that the elements have a niche, and a usize fits next to unique bits of that niche. Unfortunately, that optimization is not present in Rust yet (see the above linked issue / PR), thus there are no actual savings from this PR yet.

There is some further potential for optimization in this, in particular:

* Instead of a usize, the minimal type required for the given array size could be used.

  That would allow the use with 16bit niched types and an u8 index without any additional space even on long-addess architectures.

* Collaps EmptyNext and EmptyLast using knowledge of the free counter, allowing optimization where IT has exactly one niche and then only indexed-size bytes left.

  The last element would then have EmptyNext(anything) in it, but it wouldn't matter because free says that there's nothing left.

* Reduce the constant overhead by utilizing the "free" counter as an indicator whether next_free is valid.