### PR TITLE
[WIP] Unenforced indices

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,16 @@ impl<IT, N> sealed::Key for Key<IT, N> {
     }
 }
 
+impl sealed::Key for usize {
+    fn new(idx: usize) -> Self {
+        idx
+    }
+
+    fn index(&self) -> usize {
+        *self
+    }
+}
+
 impl<IT, N> Key<IT, N> {
     // Convenience duplicate to a) make it usable by applications without any `use slots::...::Key`
     // method, and b) to spare everyone the hassle of having a public and a sealed trait around

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -10,6 +10,26 @@ fn key_can_be_used_to_read_value() {
 }
 
 #[test]
+fn uncheckedindex_can_be_used_to_read_value() {
+    let mut slots: Slots<_, U8, usize> = Slots::new();
+    let k1 = slots.store(5).unwrap();
+    let k2 = k1.clone();
+
+    assert_eq!(5, slots.read(&k2, |&w| w));
+}
+
+#[test]
+#[should_panic(expected="explicit panic")]
+fn uncheckedindex_can_be_used_to_panic() {
+    let mut slots: Slots<_, U8, usize> = Slots::new();
+    let k1 = slots.store(5).unwrap();
+    let k2 = k1.clone();
+
+    assert_eq!(5, slots.take(k1));
+    slots.take(k2);
+}
+
+#[test]
 fn size_can_be_1() {
     let mut slots: Slots<_, U1> = Slots::new();
     let k1 = slots.store(5).unwrap();


### PR DESCRIPTION
This would allow having both the regular (never-panicking unless #4 is triggered) kind of slots instances and instances that use a different kind of key (currently an unwrapped usize, could just as well get a more scary name and `From<>`/`Into<>` implementations) where keys are not guaranteed to be usable.

This is work in progress and not meant as an immediate fix, rather as an illustration for the discussion at #2.