### PR TITLE
Verify key usage

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,8 @@ jobs:
     - name: Run tests
       run: |
         cargo build --verbose
-        cargo test --verbose
+        cargo test --verbose --no-default-features
+        cargo test --verbose --all-features
       env:
         CARGO_INCREMENTAL: '0'
         RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ==========
+* Verify that keys are used to access data in their associated Slots instances [@bugadani](https://github.com/bugadani)
 * Allow compiler to reduce memory footprint if possible [@chrysn](https://github.com/chrysn)
 * Allow using FnOnce closures in `try_read`, `read` and `modify` [@chrysn](https://github.com/chrysn)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,7 @@ exclude = [
 
 [dependencies]
 generic-array = "0.14.1"
+
+[features]
+verify_owner = []
+default = ["verify_owner"]

--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ Performance options
 =====
  * Slots provide the `verify_owner` feature that can be used to disable key owner verification.
    By default the feature is on and it is recommended to leave it enabled for development builds and disabled for release builds.
+
+   *Note: This feature requires atomic instructions, which are not generally available (for example, on ARM Cortex-M0 microcontrollers)*

--- a/README.md
+++ b/README.md
@@ -2,3 +2,8 @@ Slots [![crates.io](https://img.shields.io/crates/v/slots.svg)](https://crates.i
 =====
 
 Fixed size data structure with constant-time operations.
+
+Performance options
+=====
+ * Slots provide the `verify_owner` feature that can be used to disable key owner verification.
+   By default the feature is on and it is recommended to leave it enabled for development builds and disabled for release builds.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 
 use core::marker::PhantomData;
 #[cfg(feature = "verify_owner")]
-use core::sync::atomic::{AtomicU64, Ordering};
+use core::sync::atomic::{AtomicUsize, Ordering};
 use generic_array::{GenericArray, sequence::GenericSequence};
 
 pub use generic_array::typenum::consts;
@@ -61,7 +61,7 @@ use generic_array::typenum::Unsigned;
 
 pub struct Key<IT, N> {
     #[cfg(feature = "verify_owner")]
-    owner_id: u64,
+    owner_id: usize,
     index: usize,
     _item_marker: PhantomData<IT>,
     _size_marker: PhantomData<N>
@@ -98,7 +98,7 @@ enum EntryInner<IT> {
 pub struct Slots<IT, N>
     where N: ArrayLength<Entry<IT>> + Unsigned {
     #[cfg(feature = "verify_owner")]
-    id: u64,
+    id: usize,
     items: GenericArray<Entry<IT>, N>,
     // Could be optimized by making it just usize and relying on free_count to determine its
     // validity
@@ -107,12 +107,10 @@ pub struct Slots<IT, N>
 }
 
 #[cfg(feature = "verify_owner")]
-fn new_instance_id() -> u64 {
-    static COUNTER: AtomicU64 = AtomicU64::new(0);
+fn new_instance_id() -> usize {
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
 
-    let cnt = COUNTER.fetch_add(1, Ordering::Relaxed);
-
-    cnt
+    COUNTER.fetch_add(1, Ordering::Relaxed)
 }
 
 impl<IT, N> Slots<IT, N>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,14 +152,14 @@ impl<IT, N> Slots<IT, N>
         self.free(key.index);
         match taken.0 {
             EntryInner::Used(item) => item,
-            _ => panic!()
+            _ => unreachable!("Invalid key")
         }
     }
 
     pub fn read<T, F>(&self, key: &Key<IT, N>, function: F) -> T where F: FnOnce(&IT) -> T {
         match self.try_read(key.index, function) {
             Some(t) => t,
-            None => panic!()
+            None => unreachable!("Invalid key")
         }
     }
 
@@ -173,7 +173,7 @@ impl<IT, N> Slots<IT, N>
     pub fn modify<T, F>(&mut self, key: &Key<IT, N>, function: F) -> T where F: FnOnce(&mut IT) -> T {
         match self.items[key.index].0 {
             EntryInner::Used(ref mut item) => function(item),
-            _ => panic!()
+            _ => unreachable!("Invalid key")
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@
 #![cfg_attr(not(test), no_std)]
 
 use core::marker::PhantomData;
+#[cfg(feature = "verify_owner")]
 use core::sync::atomic::{AtomicU64, Ordering};
 use generic_array::{GenericArray, sequence::GenericSequence};
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -136,7 +136,7 @@ fn is_compact() {
 
     let mut expected_size = 32 * 16 + 3 * core::mem::size_of::<usize>();
     if cfg!(feature = "verify_owner") {
-        expected_size += 8; // an extra u64
+        expected_size += core::mem::size_of::<usize>(); // an extra usize for object id
     }
     assert_eq!(core::mem::size_of::<Slots<TwoNichesIn16Byte, U32>>(), expected_size, "Compiled size does not match expected");
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -84,6 +84,19 @@ fn store_returns_err_when_full() {
     assert!(k2.is_err());
 }
 
+#[test]
+#[should_panic(expected = "Key used in wrong instance")]
+fn use_across_slots() {
+    let mut a: Slots<u8, U4> = Slots::new();
+    let mut b: Slots<u8, U4> = Slots::new();
+
+    let k = a.store(5).expect("There should be room");
+    // Store an element in b so we don't get a different panic
+    let _ = b.store(6).expect("There should be room");
+
+    b.take(k);
+}
+
 #[should_panic(expected = "assertion failed: `(left == right)`\n  left: `792`,\n right: `536`")]
 #[test]
 /// Verify some size bounds: an N long array over IT is not larger than 3 usize + N * IT (as long


### PR DESCRIPTION
It is possible to use keys in different Slots instances that have the same type as the key owner. Add a runtime check to prevent cross-access.