### PR TITLE
[WIP] Introduce try_delete behind a type flag

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -10,6 +10,17 @@ fn key_can_be_used_to_read_value() {
 }
 
 #[test]
+#[should_panic(expected="explicit panic")]
+fn uncheckedindex_can_be_used_to_panic() {
+    let mut slots: Slots<_, U8, slots::MayPanic> = Slots::new();
+    let k1 = slots.store(5).unwrap();
+    let k2 = k1.index();
+
+    assert_eq!(Some(5), slots.try_take(k2));
+    slots.take(k1);
+}
+
+#[test]
 fn size_can_be_1() {
     let mut slots: Slots<_, U1> = Slots::new();
     let k1 = slots.store(5).unwrap();


### PR DESCRIPTION
Slots explicitly created with the MayPanic support item deletion by
index (`try_delete`), but in return have less powerful keys whose use
may result in panics (even when used in the non-try_ methods).

---

This is an alternative proposal for #5, equally drafty and more to support the discussion. Slots that use the alternative behavior are declared as `Slot<IT, N, MayPanic>` in contrast to the default `Slot<IT, N>` which has a `KeysAreValid` in the policy position.

It's a bit slimmer on the deltas, and probably a better idea altogether (especially as it does not make the key types any more complex, which might already become complex in the course of #4).

If this is taken as a route forward, it might be an option to only expose the non-try methods only for the default KeysAreValid variety of Slots, and to make the try methods accept either a usize or a key (for otherwise, access through an obtained key would be a bit awkward). The MayPanic variety indicator would need renaming in that case, but those names are straw men anyway.