### PR TITLE
Different access modes based on type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 Unreleased
 ==========
-* Provide different implementations based on AccessMode template parameter [@bugadani](https://github.com/bugadani)
+* Add Relaxed access mode to allow copyable keys and failable access [@bugadani](https://github.com/bugadani)
 * Verify that keys are used to access data in their associated Slots instances [@bugadani](https://github.com/bugadani)
 * Allow compiler to reduce memory footprint if possible [@chrysn](https://github.com/chrysn)
 * Allow using FnOnce closures in `try_read`, `read` and `modify` [@chrysn](https://github.com/chrysn)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ==========
+* Provide different implementations based on AccessMode template parameter [@bugadani](https://github.com/bugadani)
 * Verify that keys are used to access data in their associated Slots instances [@bugadani](https://github.com/bugadani)
 * Allow compiler to reduce memory footprint if possible [@chrysn](https://github.com/chrysn)
 * Allow using FnOnce closures in `try_read`, `read` and `modify` [@chrysn](https://github.com/chrysn)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,7 +258,7 @@ impl<IT, N> Slots<IT, N, Relaxed>
         }
     }
 
-    pub fn take(&mut self, key: Key<IT, N>) -> Option<IT> {
+    pub fn take(&mut self, idx: usize) -> Option<IT> {
         let taken = core::mem::replace(&mut self.items[key.index], Entry(EntryInner::EmptyLast));
         match taken.0 {
             EntryInner::Used(item) => {
@@ -269,15 +269,15 @@ impl<IT, N> Slots<IT, N, Relaxed>
         }
     }
 
-    pub fn modify<T, F>(&mut self, key: &Key<IT, N>, function: F) -> Option<T> where F: FnOnce(&mut IT) -> T {
-        match self.items[key.index].0 {
+    pub fn modify<T, F>(&mut self, idx: usize, function: F) -> Option<T> where F: FnOnce(&mut IT) -> T {
+        match self.items[idx].0 {
             EntryInner::Used(ref mut item) => Some(function(item)),
             _ => None
         }
     }
 
-    pub fn read<T, F>(&self, key: usize, function: F) -> Option<T> where F: FnOnce(&IT) -> T {
-        match &self.items[key].0 {
+    pub fn read<T, F>(&self, idx: usize, function: F) -> Option<T> where F: FnOnce(&IT) -> T {
+        match &self.items[idx].0 {
             EntryInner::Used(item) => Some(function(&item)),
             _ => None
         }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,9 +1,9 @@
-use slots::Slots;
+use slots::{Slots, Strict};
 use slots::consts::*;
 
 #[test]
 fn key_can_be_used_to_read_value() {
-    let mut slots: Slots<_, U8> = Slots::new();
+    let mut slots: Slots<_, U8, Strict> = Slots::new();
     let k1 = slots.store(5).unwrap();
 
     assert_eq!(5, slots.read(&k1, |&w| w));
@@ -11,7 +11,7 @@ fn key_can_be_used_to_read_value() {
 
 #[test]
 fn size_can_be_1() {
-    let mut slots: Slots<_, U1> = Slots::new();
+    let mut slots: Slots<_, U1, Strict> = Slots::new();
     let k1 = slots.store(5).unwrap();
 
     assert_eq!(5, slots.read(&k1, |&w| w));
@@ -27,7 +27,7 @@ fn size_can_be_1() {
 
 #[test]
 fn index_can_be_used_to_read_value() {
-    let mut slots: Slots<_, U8> = Slots::new();
+    let mut slots: Slots<_, U8, Strict> = Slots::new();
 
     slots.store(5).unwrap();
     slots.store(6).unwrap();
@@ -40,14 +40,14 @@ fn index_can_be_used_to_read_value() {
 
 #[test]
 fn trying_to_read_missing_element_returns_none() {
-    let slots: Slots<u8, U8> = Slots::new();
+    let slots: Slots<u8, U8, Strict> = Slots::new();
 
     assert_eq!(None, slots.try_read(0, |&w| w));
 }
 
 #[test]
 fn trying_to_read_deleted_element_returns_none() {
-    let mut slots: Slots<u8, U8> = Slots::new();
+    let mut slots: Slots<u8, U8, Strict> = Slots::new();
 
     slots.store(5).unwrap();
     let k = slots.store(6).unwrap();
@@ -62,7 +62,7 @@ fn trying_to_read_deleted_element_returns_none() {
 
 #[test]
 fn elements_can_be_modified_using_key() {
-    let mut slots: Slots<u8, U8> = Slots::new();
+    let mut slots: Slots<u8, U8, Strict> = Slots::new();
 
     let k = slots.store(5).unwrap();
 
@@ -75,7 +75,7 @@ fn elements_can_be_modified_using_key() {
 
 #[test]
 fn store_returns_err_when_full() {
-    let mut slots: Slots<u8, U1> = Slots::new();
+    let mut slots: Slots<u8, U1, Strict> = Slots::new();
 
     slots.store(5);
 
@@ -88,8 +88,8 @@ fn store_returns_err_when_full() {
 #[cfg(feature = "verify_owner")]
 #[should_panic(expected = "Key used in wrong instance")]
 fn use_across_slots_verify() {
-    let mut a: Slots<u8, U4> = Slots::new();
-    let mut b: Slots<u8, U4> = Slots::new();
+    let mut a: Slots<u8, U4, Strict> = Slots::new();
+    let mut b: Slots<u8, U4, Strict> = Slots::new();
 
     let k = a.store(5).expect("There should be room");
     // Store an element in b so we don't get a different panic
@@ -101,8 +101,8 @@ fn use_across_slots_verify() {
 #[test]
 #[cfg(not(feature = "verify_owner"))]
 fn use_across_slots_no_verify() {
-    let mut a: Slots<u8, U4> = Slots::new();
-    let mut b: Slots<u8, U4> = Slots::new();
+    let mut a: Slots<u8, U4, Strict> = Slots::new();
+    let mut b: Slots<u8, U4, Strict> = Slots::new();
 
     let k = a.store(5).expect("There should be room");
     // Store an element in b so we don't get a different panic
@@ -138,12 +138,12 @@ fn is_compact() {
     if cfg!(feature = "verify_owner") {
         expected_size += core::mem::size_of::<usize>(); // an extra usize for object id
     }
-    assert_eq!(core::mem::size_of::<Slots<TwoNichesIn16Byte, U32>>(), expected_size, "Compiled size does not match expected");
+    assert_eq!(core::mem::size_of::<Slots<TwoNichesIn16Byte, U32, Strict>>(), expected_size, "Compiled size does not match expected");
 }
 
 #[test]
 fn capacity_and_count() {
-    let mut slots: Slots<u8, U4> = Slots::new();
+    let mut slots: Slots<u8, U4, Strict> = Slots::new();
 
     assert_eq!(slots.capacity(), 4);
     assert_eq!(slots.count(), 0);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,5 +1,6 @@
-use slots::{Slots, Strict};
+use slots::{Slots, Strict, Relaxed};
 use slots::consts::*;
+use core::mem::size_of;
 
 #[test]
 fn key_can_be_used_to_read_value() {
@@ -132,13 +133,13 @@ fn is_compact() {
         b: bool,
     }
 
-    assert_eq!(core::mem::size_of::<TwoNichesIn16Byte>(), 16);
+    assert_eq!(size_of::<TwoNichesIn16Byte>(), 16);
 
-    let mut expected_size = 32 * 16 + 3 * core::mem::size_of::<usize>();
+    let mut expected_size = 32 * 16 + 3 * size_of::<usize>();
     if cfg!(feature = "verify_owner") {
-        expected_size += core::mem::size_of::<usize>(); // an extra usize for object id
+        expected_size += size_of::<usize>(); // an extra usize for object id
     }
-    assert_eq!(core::mem::size_of::<Slots<TwoNichesIn16Byte, U32, Strict>>(), expected_size, "Compiled size does not match expected");
+    assert_eq!(size_of::<Slots<TwoNichesIn16Byte, U32, Strict>>(), expected_size, "Compiled size does not match expected");
 }
 
 #[test]
@@ -164,4 +165,13 @@ fn capacity_and_count() {
     slots.take(k4);
 
     assert_eq!(slots.count(), 0);
+}
+
+#[test]
+fn relaxed_instance_does_not_have_object_id() {
+    if cfg!(feature = "verify_owner") {
+        assert_eq!(size_of::<Slots<u8, U4, Strict>>(), size_of::<Slots<u8, U4, Relaxed>>() + size_of::<usize>());
+    } else {
+        assert_eq!(size_of::<Slots<u8, U4, Strict>>(), size_of::<Slots<u8, U4, Relaxed>>());
+    }
 }


### PR DESCRIPTION
A different approach to the relaxed collection. Instead of providing a key and an index interface that does the same, separate the two based on type. This builds on the idea that having the relaxed makes the key-based access redundant, and thus it does not provide those methods.

~There's a slight problem with having an object id in relaxed mode, otherwise this is probably the least redundant way to provide a relaxed collection.~

- [ ] Tests