### PR TITLE
Clean up the required amount of trait bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ==========
+* Clean up the required trait bounds needed to pass around generic Slots instances [@bugadani](https://github.com/bugadani)
 * Verify that keys are used to access data in their associated Slots instances [@bugadani](https://github.com/bugadani)
 * Allow compiler to reduce memory footprint if possible [@chrysn](https://github.com/chrysn)
 * Allow using FnOnce closures in `try_read`, `read` and `modify` [@chrysn](https://github.com/chrysn)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,14 +65,12 @@
 use core::marker::PhantomData;
 #[cfg(feature = "verify_owner")]
 use core::sync::atomic::{AtomicUsize, Ordering};
-use generic_array::{GenericArray, sequence::GenericSequence};
+use generic_array::{GenericArray, ArrayLength, sequence::GenericSequence};
 
 mod private;
-
 use private::Entry;
 
 pub use generic_array::typenum::consts;
-pub use generic_array::ArrayLength;
 
 pub struct Key<IT, N> {
     #[cfg(feature = "verify_owner")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,17 @@
 //! assert_eq!(1, slots.count());
 //! ```
 //!
+//! When you need to work with arbitrarily sized Slots objects,
+//! you need to specify that the slots::Size<IT> trait is implemented for
+//! the parameter N.
+//! ```
+//! fn examine<IT, N>(slots: &Slots<IT, N>, keys: &[Key<IT, N>])
+//!     where N: slots::Size<IT>,
+//! {
+//!     unimplemented!();
+//! }
+//! ```
+//!
 
 #![cfg_attr(not(test), no_std)]
 
@@ -54,10 +65,12 @@ use core::marker::PhantomData;
 use core::sync::atomic::{AtomicUsize, Ordering};
 use generic_array::{GenericArray, sequence::GenericSequence};
 
+mod private;
+
+use private::Entry;
+
 pub use generic_array::typenum::consts;
 pub use generic_array::ArrayLength;
-
-use generic_array::typenum::Unsigned;
 
 pub struct Key<IT, N> {
     #[cfg(feature = "verify_owner")]
@@ -67,8 +80,11 @@ pub struct Key<IT, N> {
     _size_marker: PhantomData<N>
 }
 
+pub trait Size<I>: ArrayLength<Entry<I>> {}
+impl<T, I> Size<I> for T where T: ArrayLength<Entry<I>> {}
+
 impl<IT, N> Key<IT, N>
-    where N: ArrayLength<Entry<IT>> + Unsigned {
+    where N: Size<IT> {
     fn new(owner: &Slots<IT, N>, idx: usize) -> Self {
         Self {
             #[cfg(feature = "verify_owner")]
@@ -84,19 +100,11 @@ impl<IT, N> Key<IT, N>
     }
 }
 
-pub struct Entry<IT>(EntryInner<IT>);
-
-enum EntryInner<IT> {
-    Used(IT),
-    EmptyNext(usize),
-    EmptyLast
-}
-
 // Data type that stores values and returns a key that can be used to manipulate
 // the stored values.
 // Values can be read by anyone but can only be modified using the key.
 pub struct Slots<IT, N>
-    where N: ArrayLength<Entry<IT>> + Unsigned {
+    where N: Size<IT> {
     #[cfg(feature = "verify_owner")]
     id: usize,
     items: GenericArray<Entry<IT>, N>,
@@ -114,14 +122,14 @@ fn new_instance_id() -> usize {
 }
 
 impl<IT, N> Slots<IT, N>
-    where N: ArrayLength<Entry<IT>> + Unsigned {
+    where N: Size<IT> {
     pub fn new() -> Self {
         let size = N::to_usize();
 
         Self {
             #[cfg(feature = "verify_owner")]
             id: new_instance_id(),
-            items: GenericArray::generate(|i| Entry(i.checked_sub(1).map(EntryInner::EmptyNext).unwrap_or(EntryInner::EmptyLast))),
+            items: GenericArray::generate(|i| i.checked_sub(1).map(Entry::EmptyNext).unwrap_or(Entry::EmptyLast)),
             next_free: size.checked_sub(1),
             free_count: size
         }
@@ -146,8 +154,8 @@ impl<IT, N> Slots<IT, N>
 
     fn free(&mut self, idx: usize) {
         self.items[idx] = match self.next_free {
-            Some(n) => Entry(EntryInner::EmptyNext(n)),
-            None => Entry(EntryInner::EmptyLast),
+            Some(n) => Entry::EmptyNext(n),
+            None => Entry::EmptyLast,
         };
         self.next_free = Some(idx);
         self.free_count += 1;
@@ -155,9 +163,9 @@ impl<IT, N> Slots<IT, N>
 
     fn alloc(&mut self) -> Option<usize> {
         let index = self.next_free?;
-        self.next_free = match self.items[index].0 {
-            EntryInner::EmptyNext(n) => Some(n),
-            EntryInner::EmptyLast => None,
+        self.next_free = match self.items[index] {
+            Entry::EmptyNext(n) => Some(n),
+            Entry::EmptyLast => None,
             _ => unreachable!("Non-empty item in entry behind free chain"),
         };
         self.free_count -= 1;
@@ -167,7 +175,7 @@ impl<IT, N> Slots<IT, N>
     pub fn store(&mut self, item: IT) -> Result<Key<IT, N>, IT> {
         match self.alloc() {
             Some(i) => {
-                self.items[i] = Entry(EntryInner::Used(item));
+                self.items[i] = Entry::Used(item);
                 Ok(Key::new(self, i))
             }
             None => Err(item)
@@ -177,10 +185,10 @@ impl<IT, N> Slots<IT, N>
     pub fn take(&mut self, key: Key<IT, N>) -> IT {
         self.verify_key(&key);
 
-        let taken = core::mem::replace(&mut self.items[key.index], Entry(EntryInner::EmptyLast));
+        let taken = core::mem::replace(&mut self.items[key.index], Entry::EmptyLast);
         self.free(key.index);
-        match taken.0 {
-            EntryInner::Used(item) => item,
+        match taken {
+            Entry::Used(item) => item,
             _ => unreachable!("Invalid key")
         }
     }
@@ -195,8 +203,8 @@ impl<IT, N> Slots<IT, N>
     }
 
     pub fn try_read<T, F>(&self, key: usize, function: F) -> Option<T> where F: FnOnce(&IT) -> T {
-        match &self.items[key].0 {
-            EntryInner::Used(item) => Some(function(&item)),
+        match &self.items[key] {
+            Entry::Used(item) => Some(function(&item)),
             _ => None
         }
     }
@@ -204,8 +212,8 @@ impl<IT, N> Slots<IT, N>
     pub fn modify<T, F>(&mut self, key: &Key<IT, N>, function: F) -> T where F: FnOnce(&mut IT) -> T {
         self.verify_key(&key);
 
-        match self.items[key.index].0 {
-            EntryInner::Used(ref mut item) => function(item),
+        match self.items[key.index] {
+            Entry::Used(ref mut item) => function(item),
             _ => unreachable!("Invalid key")
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,9 +83,8 @@ pub struct Key<IT, N> {
 pub trait Size<I>: ArrayLength<Entry<I>> {}
 impl<T, I> Size<I> for T where T: ArrayLength<Entry<I>> {}
 
-impl<IT, N> Key<IT, N>
-    where N: Size<IT> {
-    fn new(owner: &Slots<IT, N>, idx: usize) -> Self {
+impl<IT, N> Key<IT, N> {
+    fn new(owner: &Slots<IT, N>, idx: usize) -> Self where N: Size<IT> {
         Self {
             #[cfg(feature = "verify_owner")]
             owner_id: owner.id,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,8 +50,10 @@
 //! you need to specify that the slots::Size<IT> trait is implemented for
 //! the parameter N.
 //! ```
+//! use slots::{Slots, Size, Key};
+//!
 //! fn examine<IT, N>(slots: &Slots<IT, N>, keys: &[Key<IT, N>])
-//!     where N: slots::Size<IT>,
+//!     where N: Size<IT>,
 //! {
 //!     unimplemented!();
 //! }

--- a/src/private.rs
+++ b/src/private.rs
@@ -1,0 +1,9 @@
+//! **Ignore me!** This file contains implementation details
+//! that are conceptually private but must be technically public.
+
+#[doc(hide)]
+pub enum Entry<IT> {
+    Used(IT),
+    EmptyNext(usize),
+    EmptyLast
+}


### PR DESCRIPTION
When working with generic Slots instances, it's rather complicated to specify trait bounds on the collection size and it also leaks some implementation details.

For example currently the user must write something like this:
```rust
fn examine<IT, N>(slots: &Slots<IT, N>, keys: &[Key<IT, N>])
    where N: slots::ArrayLength<slots::Entry<IT>>,
{
    unimplemented!();
}
```

After merging this PR the example changes to this:
```rust
fn examine<IT, N>(slots: &Slots<IT, N>, keys: &[Key<IT, N>])
    where N: slots::Size<IT>,
{
    unimplemented!();
}
```